### PR TITLE
aura-protocol 1.0.5: clarify disabled --url and update schema CDN pins

### DIFF
--- a/MANIFEST_VALIDATION.md
+++ b/MANIFEST_VALIDATION.md
@@ -56,7 +56,7 @@ function validateManifest(manifest: any): { valid: boolean; errors: any[] } {
 ### Core Manifest Structure
 
 **Required Fields:**
-- [ ] `$schema`: Schema URL (use `https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json` or bundled schema)
+- [ ] `$schema`: Schema URL (use `https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json` or bundled schema)
 - [ ] `protocol`: Must be `"AURA"`
 - [ ] `version`: Must be `"1.0"`
 - [ ] `site`: Site information object
@@ -108,7 +108,7 @@ Each capability must have:
 **Solution:**
 ```json
 {
-  "$schema": "https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json",
+  "$schema": "https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json",
   "protocol": "AURA",
   "version": "1.0"
 }

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Minimal example:
 
 ```json
 {
-  "$schema": "https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json",
+  "$schema": "https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json",
   "protocol": "AURA",
   "version": "1.0",
   "site": {
@@ -193,7 +193,7 @@ A more complete example with a capability:
 
 ```json
 {
-  "$schema": "https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json",
+  "$schema": "https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json",
   "protocol": "AURA",
   "version": "1.0",
   "site": {
@@ -295,7 +295,7 @@ Note: `aura-validate` currently validates local files only. Download remote mani
 The `aura-protocol` package ships:
 
 - TypeScript types for `AuraManifest`, `Resource`, `Capability`, `HttpAction`, and `AuraState`.
-- JSON Schema bundled at `dist/aura-v1.0.schema.json`. For editor tooling, reference the versioned CDN URL: `https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json`.
+- JSON Schema bundled at `dist/aura-v1.0.schema.json`. For editor tooling, reference the versioned CDN URL: `https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json`.
 - `aura-validate` CLI to validate local manifest files and cross-check resource/capability references.
 
 Installation:

--- a/packages/aura-protocol/README.md
+++ b/packages/aura-protocol/README.md
@@ -15,7 +15,7 @@ import { AuraManifest, AuraCapability, AuraState } from 'aura-protocol';
 
 // Use the TypeScript interfaces for type safety
 const manifest: AuraManifest = {
-  $schema: 'https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json',
+  $schema: 'https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json',
   protocol: 'AURA',
   version: '1.0',
   site: {
@@ -172,7 +172,7 @@ const validate = ajv.compile(schema);
 
 // Validate manifest
 const manifest: AuraManifest = {
-  $schema: 'https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json',
+  $schema: 'https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json',
   protocol: 'AURA',
   version: '1.0',
   site: { name: 'Example', url: 'https://example.com' },

--- a/packages/aura-protocol/package.json
+++ b/packages/aura-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aura-protocol",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Core TypeScript definitions and JSON Schema for the AURA protocol - making websites machine-readable for AI agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/aura-protocol/src/cli/aura-validate.ts
+++ b/packages/aura-protocol/src/cli/aura-validate.ts
@@ -29,7 +29,7 @@ const main = defineCommand({
     },
     url: {
       type: 'string',
-      description: 'Validate manifest from URL',
+      description: '(Disabled) Validate manifest from URL',
       alias: 'u',
     },
     schema: {

--- a/packages/reference-server/public/.well-known/aura.json
+++ b/packages/reference-server/public/.well-known/aura.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/aura-protocol@1.0.4/dist/aura-v1.0.schema.json",
+  "$schema": "https://unpkg.com/aura-protocol@1.0.5/dist/aura-v1.0.schema.json",
   "id": "https://aura-lighthouse.example.com/.well-known/aura.json",
   "protocol": "AURA",
   "version": "1.0",


### PR DESCRIPTION
Summary
Patch release to align CLI UX and docs with current behavior.

Changes

CLI: --url/-u is explicitly labeled (Disabled) in help; using it exits with code 1 and a clear message.

Docs: update README + MANIFEST_VALIDATION to reflect “download then validate locally.”

Examples: bump Unpkg $schema pins to aura-protocol@1.0.5.

Version: bump aura-protocol to 1.0.5.

Verification

pnpm -r build ✅

Local validation: aura-validate packages/reference-server/public/.well-known/aura.json --verbose ✅

aura-validate -u … prints disabled message and exits 1 ✅